### PR TITLE
change roberta to automodel

### DIFF
--- a/src/cnlpt/cnlp_data.py
+++ b/src/cnlpt/cnlp_data.py
@@ -131,6 +131,27 @@ def cnlp_convert_examples_to_features(
             for sent_ind,sent in enumerate(sentences):
                 sent_labels = []
 
+                ## FIXME -- this is Dongfang did for NER task using BERT, also works on roberta
+                # word_ids = batch_encoding.word_ids(batch_index=sent_ind)
+                # previous_word_idx = None
+                # label_ids = []
+                # for word_idx in word_ids:
+                #     # Special tokens have a word id that is None. We set the label to -100 so they are automatically
+                #     # ignored in the loss function.
+                #     if word_idx is None:
+                #         label_ids.append(-100)
+                #     # We set the label for the first token of each word.
+                #     elif word_idx != previous_word_idx:
+                #         label_ids.append(labels[sent_ind][word_idx])
+                #     # For the other tokens in a word, we set the label to either the current label or -100, depending on
+                #     # the label_all_tokens flag.
+                #     else:
+                #         label_ids.append(-100)
+                #     previous_word_idx = word_idx
+
+                # encoded_labels.append(label_ids)
+
+
                 ## FIXME -- this is stupid and won't work outside the roberta encoding
                 label_ind = 0
                 for wp_ind,wp in enumerate(batch_encoding[sent_ind].tokens):

--- a/src/cnlpt/train_system.py
+++ b/src/cnlpt/train_system.py
@@ -226,8 +226,8 @@ def main():
             model_args.config_name if model_args.config_name else model_args.model_name_or_path,
             cache_dir=model_args.cache_dir,
         )
-        model = CnlpRobertaForClassification.from_pretrained(
-                model_args.model_name_or_path,
+        model = CnlpRobertaForClassification(
+                model_path = model_name,
                 config=config,
                 cache_dir=model_args.cache_dir,
                 tagger=tagger,
@@ -268,8 +268,8 @@ def main():
             config.rel_attention_head_dims = model_args.head_features
 
         pretrained = True
-        model = CnlpRobertaForClassification.from_pretrained(
-            model_name,
+        model = CnlpRobertaForClassification(
+            model_path=model_name,
             config=config,
             num_labels_list=num_labels,
             cache_dir=model_args.cache_dir,
@@ -280,7 +280,7 @@ def main():
             use_prior_tasks=model_args.use_prior_tasks,
             argument_regularization=model_args.arg_reg)
         
-        model.resize_token_embeddings(len(tokenizer))
+        model.encoder.resize_token_embeddings(len(tokenizer))
 
     best_eval_results = None
     output_eval_file = os.path.join(


### PR DESCRIPTION
Mainly change two files CnlpRobertaForClassification.py  and train_system.py：
1. train_system.py： remove "from_pretrained()" from "CnlpRobertaForClassification.from_pretrained()"
2. CnlpRobertaForClassification.py: change “RobertaPreTrainedModel” to "PreTrainedModel", and load whatever model using "AutoModel.from_config()" and also initialize the weights for the auto model using "model.from_pretrained(model_path)".
3. cnlp_data.py: add lines 134-152 to avoid Roberta-specific encoding, commented for now since only tested on my own NER models, would also need to change lines 172-213 in the future.
