### PR TITLE
fix: change path import to relative package import

### DIFF
--- a/src/cnlpt/HierarchicalTransformer.py
+++ b/src/cnlpt/HierarchicalTransformer.py
@@ -9,7 +9,7 @@ import torch.nn.functional as F
 import torch
 from transformers.modeling_outputs import SequenceClassifierOutput
 
-from src.cnlpt.CnlpModelForClassification import CnlpModelForClassification, CnlpConfig
+from .CnlpModelForClassification import CnlpModelForClassification, CnlpConfig
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Without this fix, loading this module will fail if the directory `src` is not in the current `sys.path` (i.e. running anywhere other than the `cnlp_transformers` directory)