### PR TITLE
add early return with zero statuses

### DIFF
--- a/src/cnlpt/api/dtr_rest.py
+++ b/src/cnlpt/api/dtr_rest.py
@@ -58,6 +58,9 @@ async def process(doc: EntityDocument):
     instances = []
     start_time = time()
 
+    if len(doc.entities) == 0:
+        return DocTimeRelResults(statuses=[])
+
     for ent_ind, offsets in enumerate(doc.entities):
         # logger.debug('Entity ind: %d has offsets (%d, %d)' % (ent_ind, offsets[0], offsets[1]))
         inst_str = create_instance_string(doc_text, offsets)

--- a/src/cnlpt/api/negation_rest.py
+++ b/src/cnlpt/api/negation_rest.py
@@ -51,6 +51,9 @@ async def process(doc: EntityDocument):
     instances = []
     start_time = time()
 
+    if len(doc.entities) == 0:
+        return NegationResults(statuses=[])
+
     for ent_ind, offsets in enumerate(doc.entities):
         # logger.debug('Entity ind: %d has offsets (%d, %d)' % (ent_ind, offsets[0], offsets[1]))
         inst_str = create_instance_string(doc_text, offsets)


### PR DESCRIPTION
Fixes #106: for entity-based processors, return a result with an empty list of statuses if no entities were passed in.