### PR TITLE
Make sure eval_one_score metric is saved for Trainer

### DIFF
--- a/src/cnlpt/train_system.py
+++ b/src/cnlpt/train_system.py
@@ -446,6 +446,7 @@ def main(
                     model.best_score = one_score
                     model.best_eval_results = metrics
 
+            metrics["eval_one_score"] = one_score
             return metrics
 
         return compute_metrics_fn


### PR DESCRIPTION
`transformers.Trainer` was erroring out because it was looking for the `eval_one_score` metric, which we never saved for it.

This sets it in the generated metrics for `Trainer` to find.

## Traceback I was seeing
At the end of training:

```
Traceback (most recent call last):
  File "/programs/x86_64-linux/python/3.9.16/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/programs/x86_64-linux/python/3.9.16/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/root/lib/python3.9/site-packages/cnlp/train_system.py", line 556, in <module>
    main()
  File "/root/lib/python3.9/site-packages/cnlpt/train_system.py", line 466, in main
    trainer.train(
  File "/root/lib/python3.9/site-packages/transformers/trainer.py", line 1553, in train
    return inner_training_loop(
  File "/root/lib/python3.9/site-packages/transformers/trainer.py", line 1927, in _inner_training_loop
    self._maybe_log_save_evaluate(tr_loss, model, trial, epoch, ignore_keys_for_eval)
  File "/root/lib/python3.9/site-packages/transformers/trainer.py", line 2265, in _maybe_log_save_evaluate
    self._save_checkpoint(model, trial, metrics=metrics)
  File "/root/lib/python3.9/site-packages/transformers/trainer.py", line 2377, in _save_checkpoint
    metric_value = metrics[metric_to_check]
KeyError: 'eval_one_score'
```

## Is this the correct fix?

I'm not super familiar with this code path, but this seemed to be appropriate.