### PR TITLE
[FUNC] Add an option for truncation from left

### DIFF
--- a/src/cnlpt/cnlp_args.py
+++ b/src/cnlpt/cnlp_args.py
@@ -61,7 +61,12 @@ class CnlpTrainingArguments(TrainingArguments):
             "help": "If selected, probability scores will be added to the output prediction file for test data."
         },
     )
-
+    truncation_side_left: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": "Truncate samples from left. Note that hier model do not support this setting."
+        },  
+    )   
 
 cnlpt_models = ["cnn", "lstm", "hier", "cnlpt"]
 

--- a/src/cnlpt/train_system.py
+++ b/src/cnlpt/train_system.py
@@ -190,12 +190,17 @@ def main(
         )
 
     # Load tokenizer: Need this first for loading the datasets
+    if training_args.truncation_side_left and not hierarchical:
+        truncation_side = 'left'
+    else:
+        truncation_side = 'right'
     tokenizer = AutoTokenizer.from_pretrained(
         model_args.tokenizer_name
         if model_args.tokenizer_name
         else model_args.encoder_name,
         cache_dir=model_args.cache_dir,
         add_prefix_space=True,
+        truncation_side = truncation_side,
         additional_special_tokens=[
             "<e>",
             "</e>",


### PR DESCRIPTION
Minor feature update, as discussed in the Friday meeting.

When the option --truncation_side_left is selected:

* For an input sequence shorter than max_len, this option will not affect it. Padding will still be attached at the end of the example.
* For an input sequence longer than max_len, the beginning part of the sequence will be deleted to fit within the max_len restriction.