### PR TITLE
Deleted import line for ALL_PRETRAINED_CONFIG_ARCHIVE_MAP (deprecated)

### DIFF
--- a/src/cnlpt/train_system.py
+++ b/src/cnlpt/train_system.py
@@ -35,7 +35,6 @@ from transformers.training_args import IntervalStrategy
 from transformers.data.processors.utils import InputFeatures
 from transformers.tokenization_utils import PreTrainedTokenizer
 from transformers.data.processors.utils import DataProcessor, InputExample, InputFeatures
-from transformers import ALL_PRETRAINED_CONFIG_ARCHIVE_MAP
 from torch.optim import AdamW
 from transformers.file_utils import CONFIG_NAME
 from huggingface_hub import hf_hub_url


### PR DESCRIPTION
It seems ALL_PRETRAINED_CONFIG_ARCHIVE_MAP was deprecated https://github.com/huggingface/transformers/pull/21207

Also I don't see it used anywhere in train_system.py