### PR TITLE
Experimental macOS/MPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,15 @@ Primary use cases include
 This library is _not_ intended to serve as a place for clinical NLP applications to live. If you build something cool that uses transformer models that take advantage of our model definitions, the best practice is probably to rely on it as a library rather than treating it as your workspace. This library is also not intended as a deployment-ready tool for _scalable_ clinical NLP. There is a lot of interest in developing methods and tools that are smaller and can process millions of records, and this library can potentially be used for research along those line. But it will probably never be extremely optimized or shrink-wrapped for applications. However, there should be plenty of examples and useful code for people who are interested in that type of deployment.
 
 ## Install
+> [!WARNING]
+**Due to some dependency issues, this package does not officially
+support macOS on Apple Silicon.**
+For experimental support, use python 3.10 and run 
+`pip install -r macos-requirements.txt` between steps 3 and 4 
+of the [editable installation](#editable-installation) instructions below.
 
-**Note: due to some dependency issues, this package does not officially
-support macOS on Apple Silicon. For experimental support, run `pip install -r macos-requirements.txt` between steps 3 and 4 of the [editable installation](#editable-installation) instructions below.**
-
-**Note:** When installing the library's dependencies, `pip` will probably install 
+> [!NOTE] 
+When installing the library's dependencies, `pip` will probably install 
 PyTorch with CUDA 10.2 support by default. If you would like to run the 
 library in CPU-only mode or with a newer version of CUDA, [install PyTorch 
 to your desired specifications](https://pytorch.org/get-started/locally/) 
@@ -67,7 +71,7 @@ To use the library for fine-tuning, you'll need to take the following steps:
 1. Write your dataset to one of the following formats in a folder with train, dev, and test files:
   1. csv or tsv: The first row should have column names separated by comma or tab. The name ```text``` has special meaning as the input string. Likewise if there are columns named ```text_a``` and ```text_b``` it will be interpreted as two parts of a transformer input string separated by a <sep>-token equivalent. All other columns are treated as potential targets -- their names can be passed to the ```train_system.py``` script as ```--task_name``` arguments. For tagging targets, the field must consist of space-delimited labels, one per space-delimited token in the ```text``` field. For relation extraction targets, the field must be a ``` , ``` delimited list of relation tuples, where each relation tuple is (<offset 1>, <offset 2>,label), where offset 1 and 2 are token indices into the space-delimited tokens in the ```text``` field.
   2. json: The file format must be the following:
-  ```
+  ```json
     { 'data': [
         { 'text': <text of instance>,
           'id': <instance id>

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ This library is _not_ intended to serve as a place for clinical NLP applications
 ## Install
 
 **Note: due to some dependency issues, this package does not officially
-support macOS on Apple Silicon. If you want to install it on Apple Silicon,
-you are on your own; we unofficially recommend trying it with Python 3.10, or using
-the docker CPU image**
+support macOS on Apple Silicon. For experimental support, run `pip install -r macos-requirements.txt` between steps 3 and 4 of the [editable installation](#editable-installation) instructions below.**
 
 **Note:** When installing the library's dependencies, `pip` will probably install 
 PyTorch with CUDA 10.2 support by default. If you would like to run the 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,7 @@ This library is _not_ intended to serve as a place for clinical NLP applications
 
 ## Install
 > [!WARNING]
-**Due to some dependency issues, this package does not officially
-support macOS on Apple Silicon.**
-For experimental support, use python 3.10 and run 
-`pip install -r macos-requirements.txt` before installing the package.
+macOS support is currently experimental. We recommend using python3.10 for macOS installations.
 
 > [!NOTE] 
 When installing the library's dependencies, `pip` will probably install 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To use the library for fine-tuning, you'll need to take the following steps:
 1. Write your dataset to one of the following formats in a folder with train, dev, and test files:
   1. csv or tsv: The first row should have column names separated by comma or tab. The name ```text``` has special meaning as the input string. Likewise if there are columns named ```text_a``` and ```text_b``` it will be interpreted as two parts of a transformer input string separated by a <sep>-token equivalent. All other columns are treated as potential targets -- their names can be passed to the ```train_system.py``` script as ```--task_name``` arguments. For tagging targets, the field must consist of space-delimited labels, one per space-delimited token in the ```text``` field. For relation extraction targets, the field must be a ``` , ``` delimited list of relation tuples, where each relation tuple is (<offset 1>, <offset 2>,label), where offset 1 and 2 are token indices into the space-delimited tokens in the ```text``` field.
   2. json: The file format must be the following:
-  ```json
+  ```
     { 'data': [
         { 'text': <text of instance>,
           'id': <instance id>

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ This library is _not_ intended to serve as a place for clinical NLP applications
 **Due to some dependency issues, this package does not officially
 support macOS on Apple Silicon.**
 For experimental support, use python 3.10 and run 
-`pip install -r macos-requirements.txt` between steps 3 and 4 
-of the [editable installation](#editable-installation) instructions below.
+`pip install -r macos-requirements.txt` before installing the package.
 
 > [!NOTE] 
 When installing the library's dependencies, `pip` will probably install 

--- a/macos-requirements.txt
+++ b/macos-requirements.txt
@@ -1,0 +1,7 @@
+setuptools>=61.0.0
+wheel
+Cython>=0.25,<3.0
+numpy
+spacy>=3.0.0, <=3.6
+PyFastNER>=1.0.8
+quicksectx>=0.3.5

--- a/macos-requirements.txt
+++ b/macos-requirements.txt
@@ -1,7 +1,0 @@
-setuptools>=61.0.0
-wheel
-Cython>=0.25,<3.0
-numpy
-spacy>=3.0.0, <=3.6
-PyFastNER>=1.0.8
-quicksectx>=0.3.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     requests~=2.26.0
     scikit-learn~=1.0.2
     seqeval~=1.2.2
-    torch>=1.5
+    torch>=1.5, <=2.3.1
     transformers[torch]>=4.15, <4.42
     uvicorn[standard]~=0.16.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,12 +31,12 @@ install_requires =
     numpy~=1.23.3
     pandas~=1.3.5
     pydantic~=1.10.8
-    PyRuSH~=1.0.3.6
+    PyRuSH~=1.0.8
     requests~=2.26.0
     scikit-learn~=1.0.2
     seqeval~=1.2.2
-    torch~=1.5
-    transformers[torch]~=4.15
+    torch>=1.5
+    transformers[torch]>=4.15, <4.42
     uvicorn[standard]~=0.16.0
 
 [options.entry_points]

--- a/src/cnlpt/api/dtr_rest.py
+++ b/src/cnlpt/api/dtr_rest.py
@@ -49,7 +49,7 @@ class DocTimeRelResults(BaseModel):
 
 @app.on_event("startup")
 async def startup_event():
-    initialize_cnlpt_model(app, model_name, cuda=False, batch_size=64)
+    initialize_cnlpt_model(app, model_name, device="cpu", batch_size=64)
 
 @app.post("/dtr/process")
 async def process(doc: EntityDocument):

--- a/src/cnlpt/notebooks/viz_negation.ipynb
+++ b/src/cnlpt/notebooks/viz_negation.ipynb
@@ -55,10 +55,15 @@
     "AutoConfig.register(\"cnlpt\", CnlpConfig)\n",
     "AutoModel.register(CnlpConfig, CnlpModelForClassification)\n",
     "\n",
+    "import torch\n",
+    "import torch.backends.mps\n",
+    "\n",
+    "device = 'cuda' if torch.cuda.is_available() else 'mps' if torch.backends.mps.is_available() else 'cpu'\n",
+    "\n",
     "config = AutoConfig.from_pretrained(model_name)\n",
     "tokenizer = AutoTokenizer.from_pretrained(model_name, config=config)\n",
     "model = CnlpModelForClassification.from_pretrained(model_name, config=config)\n",
-    "model.to('cuda')\n",
+    "model.to(device)\n",
     "trainer = Trainer(model=model, args=training_args, compute_metrics=None)"
    ]
   },
@@ -85,7 +90,7 @@
    "outputs": [],
    "source": [
     "print(inputs)\n",
-    "outputs = model(inputs.to('cuda'), output_attentions=True)"
+    "outputs = model(inputs.to(device), output_attentions=True)"
    ]
   },
   {
@@ -170,7 +175,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds experimental MPS support, including updated package dependencies for macOS and MPS acceleration for models served by the API.

The following dependencies have been updated in `setup.cfg`:
- `PyRuSH`: `1.0.3.6` → `1.0.8`
  An issue with the build script in older versions of PyRuSH prevented the wheel from building on macOS
- `torch`: `~=1.5` → `>=1.5, <=2.3.1`
  More current versions of torch have much improved mps support, with more operations supported by the backend.
  I realize this dependency now spans two major versions of pytorch... should we consider committing to 2.x?
- `transformers`: `~=4.15` → `>=4.15, <4.42`
  transformers 4.42 seems to be causing the following error on mps when loading models:
  `RuntimeError: Placeholder storage has not been allocated on MPS device!`
  This error doesn't occur with transformers <4.42.

This PR also adds some checks to use the MPS device when possible, specifically for models served by the API. Training scripts already use MPS by default because we're using the HF Trainer class, which does this for us.

This implementation Works On My Machine™, but more testing is needed to make sure this definitively solves all the build dependency issues. I'm opening this on main rather than dev because all it should do is increase compatibility for macOS users—but let me know if adapting this for the latest dev version makes more sense.
