### PR TITLE
Fix evaluation KeyError for "eval_one_score" and model loading issue for ModernBERT

### DIFF
--- a/src/cnlpt/train_system.py
+++ b/src/cnlpt/train_system.py
@@ -715,6 +715,7 @@ def main(
                             )
                         )
 
+            metrics["one_score"] = one_score
             return metrics
 
         return compute_metrics_fn


### PR DESCRIPTION
This fixes the following error during evaluation:  ``KeyError: "The `metric_for_best_model` training argument is set to 'eval_one_score', which is not found in the evaluation metrics.``

Looking back at the discussion in #190, there was some concern about saving the model twice. Not sure if this is still an issue...

This also fixes an issue that was causing the final best model load at the end of training to fail for ModernBERT fine-tuning.