### PR TITLE
Enable --resume_from_checkpoint and warn if model has different cnlpt version

### DIFF
--- a/src/cnlpt/train_system/cnlp_train_system.py
+++ b/src/cnlpt/train_system/cnlp_train_system.py
@@ -32,7 +32,11 @@ from .display import TrainSystemDisplay
 from .log import configure_logger_for_training, logger
 from .metrics import TaskEvalPrediction
 from .training_callbacks import BasicLoggingCallback, DisplayCallback
-from .utils import is_external_encoder, simple_softmax, warn_if_old_checkpoint
+from .utils import (
+    is_external_encoder,
+    simple_softmax,
+    warn_if_chekpoint_version_mismatch,
+)
 
 
 class CnlpTrainSystem:
@@ -570,7 +574,7 @@ class CnlpTrainSystem:
 
             resume_from_checkpoint = self.training_args.resume_from_checkpoint
             if resume_from_checkpoint is not None:
-                warn_if_old_checkpoint(resume_from_checkpoint, logger)
+                warn_if_chekpoint_version_mismatch(resume_from_checkpoint, logger)
 
             trainer.train(resume_from_checkpoint=resume_from_checkpoint)
             trainer.save_model()

--- a/src/cnlpt/train_system/cnlp_train_system.py
+++ b/src/cnlpt/train_system/cnlp_train_system.py
@@ -32,7 +32,7 @@ from .display import TrainSystemDisplay
 from .log import configure_logger_for_training, logger
 from .metrics import TaskEvalPrediction
 from .training_callbacks import BasicLoggingCallback, DisplayCallback
-from .utils import is_external_encoder, simple_softmax
+from .utils import is_external_encoder, simple_softmax, warn_if_old_checkpoint
 
 
 class CnlpTrainSystem:
@@ -568,7 +568,11 @@ class CnlpTrainSystem:
             if self.disp:
                 self.disp.eval_desc = "Evaluating"
 
-            trainer.train()
+            resume_from_checkpoint = self.training_args.resume_from_checkpoint
+            if resume_from_checkpoint is not None:
+                warn_if_old_checkpoint(resume_from_checkpoint, logger)
+
+            trainer.train(resume_from_checkpoint=resume_from_checkpoint)
             trainer.save_model()
 
             if self.training_args.do_predict:

--- a/src/cnlpt/train_system/utils.py
+++ b/src/cnlpt/train_system/utils.py
@@ -1,5 +1,12 @@
+import json
+import logging
+import os
+from typing import Any, Union
+
 import numpy as np
 from transformers.models.auto.configuration_auto import AutoConfig
+
+from .. import __version__ as cnlpt_version
 
 
 def is_cnlpt_model(model_path: str) -> bool:
@@ -33,3 +40,30 @@ def is_external_encoder(model_name_or_path: str) -> bool:
 def simple_softmax(x: list):
     """Softmax values for 1-D score array"""
     return np.exp(x) / np.sum(np.exp(x), axis=0)
+
+
+def warn_if_old_checkpoint(
+    checkpoint_dir: str, logger: logging.Logger
+) -> Union[str, None]:
+    warning: Union[str, None] = None
+
+    checkpoint_config_path = os.path.join(checkpoint_dir, "config.json")
+    with open(checkpoint_config_path) as f:
+        checkpoint_config: dict[str, Any] = json.load(f)
+
+    ckpt_version: Union[str, None] = checkpoint_config.get("cnlpt_version", None)
+    if ckpt_version is None:
+        warning = f"The checkpoint at {checkpoint_dir} does not specify a `cnlpt_version`, and may be incompatible with this version of cnlpt"
+        return
+    else:
+        ckpt_maj_min = tuple(ckpt_version.split(".", maxsplit=2)[:2])
+        cnlpt_maj_min = tuple(cnlpt_version.split(".", maxsplit=2)[:2])
+
+        if ckpt_maj_min != cnlpt_maj_min:
+            warning = f"The checkpoint at {checkpoint_dir} was created with cnlpt version {ckpt_version}, but this is version {cnlpt_version}. Be aware that the checkpoint may be incompatible."
+
+    if warning is not None:
+        import warnings
+
+        warnings.warn(warning)
+        logger.warning(warning)

--- a/src/cnlpt/train_system/utils.py
+++ b/src/cnlpt/train_system/utils.py
@@ -42,7 +42,7 @@ def simple_softmax(x: list):
     return np.exp(x) / np.sum(np.exp(x), axis=0)
 
 
-def warn_if_old_checkpoint(
+def warn_if_chekpoint_version_mismatch(
     checkpoint_dir: str, logger: logging.Logger
 ) -> Union[str, None]:
     warning: Union[str, None] = None


### PR DESCRIPTION
Enables using `--resume_from_checkpoint` to resume training partway through, and warns if the checkpoint's cnlpt version does not match the current version of cnlpt.

Resolves #234.