### PR TITLE
Fix labels having incorrect dtype in CnlpPredictions

### DIFF
--- a/src/cnlpt/data/predictions.py
+++ b/src/cnlpt/data/predictions.py
@@ -77,7 +77,9 @@ class CnlpPredictions:
             # and all the tasks must be classification. This reflects how we structure
             # the data during preprocessing.
             assert all(t.type == CLASSIFICATION for t in tasks)
-            task_labels = {t.name: self.raw.label_ids[:, t.index] for t in tasks}
+            task_labels = {
+                t.name: self.raw.label_ids[:, t.index].astype(int) for t in tasks
+            }
         else:
             assert self.raw.label_ids.ndim == 3
             # If our labels are 3 dimensional, then label_ids has shape (batch, max_seq, L)


### PR DESCRIPTION
For datasets with only classification tasks, there was a missing conversion ensuring that the `label_ids` in `CnlpPredictions` was integer typed. This led to an error when trying to convert label ids to label values because a floating point label_id couldn't be used to index into a list of label strings. This surfaced when converting predictions to a dataframe in the `make_preds_df()` function in `cnlpt.data.analysis`.