### PR TITLE
Get batch_size and seq_len from encoder outputs instead of inputs

### DIFF
--- a/src/cnlpt/modeling/models/projection_model.py
+++ b/src/cnlpt/modeling/models/projection_model.py
@@ -293,7 +293,7 @@ class ProjectionModel(PreTrainedModel):
 
         outputs = self.encoder(input_ids, **kwargs)
 
-        batch_size, seq_len = input_ids.shape
+        batch_size, seq_len, _ = outputs.last_hidden_state.shape
 
         logits = []
 


### PR DESCRIPTION
Previously we relied on `input_ids` being passed to the projection model's `forward()` method—but `input_ids` can be `None` if `inputs_embeds` is provided instead. Either way, we can just get `batch_size` and `seq_len` from the output of the encoder.

This error surfaced when testing the token/sentence attribution REST pipeline in the `rest_interp` branch.