### PR TITLE
Add per-class token and sentence attributions with interactive visualizer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ Homepage = "https://github.com/Machine-Learning-for-Medical-Language/cnlp_transf
 where = ["src"]
 include = ["cnlpt*"]
 
+[tool.setuptools.package-data]
+"cnlpt.rest" = ["*.html"]
+
 [dependency-groups]
 lint = [
     "ruff==0.11.8", # same as in pre-commit hooks and CI

--- a/src/cnlpt/modeling/models/projection_model.py
+++ b/src/cnlpt/modeling/models/projection_model.py
@@ -293,7 +293,7 @@ class ProjectionModel(PreTrainedModel):
 
         outputs = self.encoder(input_ids, **kwargs)
 
-        batch_size, seq_len = input_ids.shape
+        batch_size, seq_len, _ = outputs.last_hidden_state.shape
 
         logits = []
 

--- a/src/cnlpt/rest/cnlp_rest.py
+++ b/src/cnlpt/rest/cnlp_rest.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from collections.abc import Iterable
 from typing import Union
 
@@ -19,6 +20,15 @@ from ..data.preprocess import preprocess_raw_data
 from ..data.task_info import CLASSIFICATION, RELATIONS, TAGGING, TaskInfo
 from ..modeling.config.hierarchical_config import HierarchicalModelConfig
 from ..modeling.load import try_load_config
+
+
+# Splits on sentence-ending punctuation followed by whitespace + uppercase —
+# reliable for LLM-generated clinical prose.
+_SENTENCE_RE = re.compile(r'(?<=[.!?])\s+(?=[A-Z])')
+
+
+def _split_sentences(text: str) -> list[str]:
+    return [s.strip() for s in _SENTENCE_RE.split(text.strip()) if s.strip()]
 
 
 class InputDocument(BaseModel):
@@ -177,6 +187,165 @@ class CnlpRestApp:
 
         return df.to_dicts()
 
+    def _compute_attributions(
+        self,
+        text_list: list[str],
+        max_seq_length: int = 128,
+    ) -> list[dict[str, list[dict]]]:
+        """Compute input × gradient token-level saliency for each task.
+
+        For every (input, task) pair runs a single forward+backward pass and
+        returns per-token scores as the L2 norm of (gradient × embedding),
+        normalized to [0, 1] within each sample.
+
+        Returns a list (one entry per input text) of dicts mapping task name
+        to a list of {"token": str, "score": float} objects, one per
+        non-padding token.
+        """
+        if not hasattr(self.model.encoder, "embeddings"):
+            raise NotImplementedError(
+                "Input × gradient attribution is only supported for encoder "
+                "architectures that expose an 'embeddings' submodule (e.g. BERT)."
+            )
+
+        encoding = self.tokenizer(
+            text_list,
+            max_length=max_seq_length,
+            padding="max_length",
+            truncation=True,
+            return_tensors="pt",
+        )
+        input_ids = encoding["input_ids"].to(self.device)
+        attention_mask = encoding["attention_mask"].to(self.device)
+        token_type_ids = encoding.get("token_type_ids")
+        if token_type_ids is not None:
+            token_type_ids = token_type_ids.to(self.device)
+
+        # Compute full input embeddings (word + position + token_type) once,
+        # outside the gradient tape.
+        embed_kwargs: dict = {"input_ids": input_ids}
+        if token_type_ids is not None:
+            embed_kwargs["token_type_ids"] = token_type_ids
+        with torch.no_grad():
+            base_embeds = self.model.encoder.embeddings(**embed_kwargs)
+
+        self.model.eval()
+        results_per_task: dict[str, list] = {}
+
+        for task_ind, task in enumerate(self.tasks):
+            # Fresh leaf tensor per task so gradients don't accumulate.
+            inputs_embeds = base_embeds.detach().requires_grad_(True)
+
+            output = self.model(
+                inputs_embeds=inputs_embeds,
+                attention_mask=attention_mask,
+            )
+            task_logits = output.logits[task_ind]  # (batch, num_labels)
+
+            # Differentiate the predicted-class score summed over the batch.
+            pred_classes = task_logits.argmax(dim=-1)
+            score = task_logits[torch.arange(len(text_list)), pred_classes].sum()
+            score.backward()
+
+            # Input × gradient, L2-normed over the hidden dimension → (batch, seq)
+            grad = inputs_embeds.grad
+            saliency = (grad * inputs_embeds.detach()).norm(dim=-1)
+
+            # Zero out padding, then normalize each sample to [0, 1].
+            saliency = saliency * attention_mask.float()
+            saliency_max = saliency.max(dim=-1, keepdim=True).values.clamp(min=1e-10)
+            saliency = (saliency / saliency_max).detach().cpu()
+
+            input_ids_cpu = input_ids.cpu()
+            attn_cpu = attention_mask.cpu()
+
+            task_results = []
+            for i in range(len(text_list)):
+                tokens = self.tokenizer.convert_ids_to_tokens(input_ids_cpu[i])
+                task_results.append(
+                    [
+                        {"token": tok, "score": round(saliency[i, j].item(), 4)}
+                        for j, (tok, m) in enumerate(zip(tokens, attn_cpu[i]))
+                        if m == 1
+                    ]
+                )
+            results_per_task[task.name] = task_results
+
+        return [
+            {
+                task_name: task_results[i]
+                for task_name, task_results in results_per_task.items()
+            }
+            for i in range(len(text_list))
+        ]
+
+    def _compute_sentence_attributions(
+        self,
+        text_list: list[str],
+        max_seq_length: int = 128,
+    ) -> list[dict[str, list[dict]]]:
+        """Leave-one-sentence-out ablation for each task.
+
+        For each sentence, removes it from the input and computes:
+            score = p(predicted_class | full text) - p(predicted_class | text without sentence)
+
+        Positive: the sentence supports the prediction.
+        Negative: the sentence suppresses it.
+
+        Returns a list (one per input text) of dicts mapping task name to a list
+        of {"sentence": str, "score": float} objects.
+        """
+        self.model.eval()
+        all_results: list[dict[str, list[dict]]] = []
+
+        for text in text_list:
+            sentences = _split_sentences(text)
+
+            if len(sentences) < 2:
+                all_results.append(
+                    {task.name: [{"sentence": s, "score": 0.0} for s in sentences]
+                     for task in self.tasks}
+                )
+                continue
+
+            # index 0 = full text, indices 1..N = each sentence removed
+            ablated = [
+                " ".join(s for j, s in enumerate(sentences) if j != i)
+                for i in range(len(sentences))
+            ]
+            batch_texts = [text] + ablated
+
+            encoding = self.tokenizer(
+                batch_texts,
+                max_length=max_seq_length,
+                padding="max_length",
+                truncation=True,
+                return_tensors="pt",
+            )
+            input_ids = encoding["input_ids"].to(self.device)
+            attention_mask = encoding["attention_mask"].to(self.device)
+
+            with torch.no_grad():
+                output = self.model(input_ids=input_ids, attention_mask=attention_mask)
+
+            task_results: dict[str, list[dict]] = {}
+            for task_ind, task in enumerate(self.tasks):
+                probs = torch.softmax(output.logits[task_ind], dim=-1)
+                pred_class = probs[0].argmax().item()
+                baseline_prob = probs[0, pred_class].item()
+
+                task_results[task.name] = [
+                    {
+                        "sentence": sent,
+                        "score": round(baseline_prob - probs[i + 1, pred_class].item(), 4),
+                    }
+                    for i, sent in enumerate(sentences)
+                ]
+
+            all_results.append(task_results)
+
+        return all_results
+
     def process(
         self,
         input_doc: InputDocument,
@@ -184,6 +353,8 @@ class CnlpRestApp:
         chunk_len: Union[int, None] = None,
         num_chunks: Union[int, None] = None,
         prepend_empty_chunk: bool = False,
+        return_attributions: bool = False,
+        return_sentence_attributions: bool = False,
     ):
         if isinstance(self.config, HierarchicalModelConfig):
             hier_data_config = HierarchicalDataConfig(
@@ -194,11 +365,26 @@ class CnlpRestApp:
         else:
             hier_data_config = None
 
-        dataset = self.create_prediction_dataset(
-            input_doc.to_text_list(), max_seq_length, hier_data_config
-        )
+        text_list = input_doc.to_text_list()
+        dataset = self.create_prediction_dataset(text_list, max_seq_length, hier_data_config)
         predictions = self.predict(dataset, max_seq_length)
-        return self.format_predictions(predictions)
+        results = self.format_predictions(predictions)
+
+        if return_attributions:
+            attributions = self._compute_attributions(text_list, max_seq_length)
+            for result, doc_attrs in zip(results, attributions):
+                for task_name, token_scores in doc_attrs.items():
+                    if task_name in result:
+                        result[task_name]["attributions"] = token_scores
+
+        if return_sentence_attributions:
+            sent_attrs = self._compute_sentence_attributions(text_list, max_seq_length)
+            for result, doc_attrs in zip(results, sent_attrs):
+                for task_name, sentence_scores in doc_attrs.items():
+                    if task_name in result:
+                        result[task_name]["sentence_attributions"] = sentence_scores
+
+        return results
 
     def router(self, prefix: str = ""):
         router = APIRouter(prefix=prefix)

--- a/src/cnlpt/rest/cnlp_rest.py
+++ b/src/cnlpt/rest/cnlp_rest.py
@@ -1,12 +1,14 @@
 import logging
 import re
 from collections.abc import Iterable
+from importlib.resources import files
 from typing import Union
 
 import polars as pl
 import torch
 from datasets import Dataset
 from fastapi import APIRouter, FastAPI
+from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 from transformers.models.auto.modeling_auto import AutoModel
 from transformers.trainer import Trainer
@@ -21,10 +23,8 @@ from ..data.task_info import CLASSIFICATION, RELATIONS, TAGGING, TaskInfo
 from ..modeling.config.hierarchical_config import HierarchicalModelConfig
 from ..modeling.load import try_load_config
 
-
-# Splits on sentence-ending punctuation followed by whitespace + uppercase —
-# reliable for LLM-generated clinical prose.
-_SENTENCE_RE = re.compile(r'(?<=[.!?])\s+(?=[A-Z])')
+# Splits on sentence-ending punctuation followed by whitespace + uppercase
+_SENTENCE_RE = re.compile(r"(?<=[.!?])\s+(?=[A-Z])")
 
 
 def _split_sentences(text: str) -> list[str]:
@@ -192,19 +192,29 @@ class CnlpRestApp:
         text_list: list[str],
         max_seq_length: int = 128,
     ) -> list[dict[str, list[dict]]]:
-        """Compute input × gradient token-level saliency for each task.
+        """Compute signed per-class input x gradient token-level attributions.
 
-        For every (input, task) pair runs a single forward+backward pass and
-        returns per-token scores as the L2 norm of (gradient × embedding),
-        normalized to [0, 1] within each sample.
+        Runs one forward pass, then one backward pass per class label.
+        Per-token scores are the dot product of (gradient x embedding)
+        summed over the hidden dimension, normalized per class to [-1, 1]
+        within each sample.
+
+        - Positive score: token pushes the model toward that class.
+        - Negative score: token pushes the model away from that class.
+
+        Only classification tasks are supported.
 
         Returns a list (one entry per input text) of dicts mapping task name
-        to a list of {"token": str, "score": float} objects, one per
-        non-padding token.
+        to a list of {"token_id": int, "start": int, "end": int,
+        "scores": {"label_a": float, ...}} objects, one per non-padding token.
+        start/end are character offsets into the original input string, so
+        text[start:end] gives the corresponding substring and
+        "".join(text[s:e] for s, e in ...) reconstructs the original
+        (excluding special tokens, which have start == end == 0).
         """
         if not hasattr(self.model.encoder, "embeddings"):
             raise NotImplementedError(
-                "Input × gradient attribution is only supported for encoder "
+                "Input x gradient attribution is only supported for encoder "
                 "architectures that expose an 'embeddings' submodule (e.g. BERT)."
             )
 
@@ -214,58 +224,78 @@ class CnlpRestApp:
             padding="max_length",
             truncation=True,
             return_tensors="pt",
+            return_offsets_mapping=True,
         )
         input_ids = encoding["input_ids"].to(self.device)
         attention_mask = encoding["attention_mask"].to(self.device)
         token_type_ids = encoding.get("token_type_ids")
         if token_type_ids is not None:
             token_type_ids = token_type_ids.to(self.device)
+        # token offsets stay on CPU
+        offset_mapping = encoding["offset_mapping"]  # (batch, seq, 2)
 
-        # Compute full input embeddings (word + position + token_type) once,
-        # outside the gradient tape.
+        # compute embeddings first without grad
         embed_kwargs: dict = {"input_ids": input_ids}
         if token_type_ids is not None:
             embed_kwargs["token_type_ids"] = token_type_ids
         with torch.no_grad():
             base_embeds = self.model.encoder.embeddings(**embed_kwargs)
 
+        # forward pass from embeddings
         self.model.eval()
+        inputs_embeds = base_embeds.detach().requires_grad_(True)
+        output = self.model(
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+        )
+
+        batch_size = len(text_list)
+
         results_per_task: dict[str, list] = {}
-
         for task_ind, task in enumerate(self.tasks):
-            # Fresh leaf tensor per task so gradients don't accumulate.
-            inputs_embeds = base_embeds.detach().requires_grad_(True)
+            if task.type != CLASSIFICATION:
+                self.logger.warning(
+                    f"Skipping token attributions for task {task.name}, since it is not a classification task."
+                )
+                continue
 
-            output = self.model(
-                inputs_embeds=inputs_embeds,
-                attention_mask=attention_mask,
-            )
             task_logits = output.logits[task_ind]  # (batch, num_labels)
 
-            # Differentiate the predicted-class score summed over the batch.
-            pred_classes = task_logits.argmax(dim=-1)
-            score = task_logits[torch.arange(len(text_list)), pred_classes].sum()
-            score.backward()
+            # One backward pass per class, reusing the graph via retain_graph=True.
+            class_attrs: list[torch.Tensor] = []
+            for c in range(len(task.labels)):
+                if inputs_embeds.grad is not None:
+                    inputs_embeds.grad.zero_()
+                task_logits[:, c].sum().backward(retain_graph=True)
+                # Signed dot product over hidden dim → (batch, seq)
+                signed_attr = (inputs_embeds.grad * inputs_embeds.detach()).sum(dim=-1)
+                class_attrs.append(signed_attr.detach())
 
-            # Input × gradient, L2-normed over the hidden dimension → (batch, seq)
-            grad = inputs_embeds.grad
-            saliency = (grad * inputs_embeds.detach()).norm(dim=-1)
+            # Stack to (batch, seq, num_labels); mask padding.
+            attrs = torch.stack(class_attrs, dim=-1)
+            attrs = attrs * attention_mask.float().unsqueeze(-1)
 
-            # Zero out padding, then normalize each sample to [0, 1].
-            saliency = saliency * attention_mask.float()
-            saliency_max = saliency.max(dim=-1, keepdim=True).values.clamp(min=1e-10)
-            saliency = (saliency / saliency_max).detach().cpu()
+            # Normalize each class independently per sample to [-1, 1].
+            norm_denom = attrs.abs().max(dim=1, keepdim=True).values.clamp(min=1e-10)
+            attrs = (attrs / norm_denom).cpu()
 
             input_ids_cpu = input_ids.cpu()
             attn_cpu = attention_mask.cpu()
 
             task_results = []
-            for i in range(len(text_list)):
-                tokens = self.tokenizer.convert_ids_to_tokens(input_ids_cpu[i])
+            for i in range(batch_size):
                 task_results.append(
                     [
-                        {"token": tok, "score": round(saliency[i, j].item(), 4)}
-                        for j, (tok, m) in enumerate(zip(tokens, attn_cpu[i]))
+                        {
+                            "token_id": input_ids_cpu[i, j].item(),
+                            "start": offset_mapping[i, j, 0].item(),
+                            "end": offset_mapping[i, j, 1].item(),
+                            "scores": {
+                                label: attrs[i, j, c].item()
+                                for c, label in enumerate(task.labels)
+                            },
+                        }
+                        for j, m in enumerate(attn_cpu[i])
                         if m == 1
                     ]
                 )
@@ -276,7 +306,7 @@ class CnlpRestApp:
                 task_name: task_results[i]
                 for task_name, task_results in results_per_task.items()
             }
-            for i in range(len(text_list))
+            for i in range(batch_size)
         ]
 
     def _compute_sentence_attributions(
@@ -286,14 +316,17 @@ class CnlpRestApp:
     ) -> list[dict[str, list[dict]]]:
         """Leave-one-sentence-out ablation for each task.
 
-        For each sentence, removes it from the input and computes:
-            score = p(predicted_class | full text) - p(predicted_class | text without sentence)
+        For each sentence and each class label, removes the sentence from the
+        input and computes:
+            score = p(class | full text) - p(class | text without sentence)
 
-        Positive: the sentence supports the prediction.
+        Positive: the sentence supports that class.
         Negative: the sentence suppresses it.
 
+        Only classification tasks are supported.
+
         Returns a list (one per input text) of dicts mapping task name to a list
-        of {"sentence": str, "score": float} objects.
+        of {"sentence": str, "scores": {"label_a": float, ...}} objects.
         """
         self.model.eval()
         all_results: list[dict[str, list[dict]]] = []
@@ -303,8 +336,17 @@ class CnlpRestApp:
 
             if len(sentences) < 2:
                 all_results.append(
-                    {task.name: [{"sentence": s, "score": 0.0} for s in sentences]
-                     for task in self.tasks}
+                    {
+                        task.name: [
+                            {
+                                "sentence": s,
+                                "scores": {label: 0.0 for label in task.labels},
+                            }
+                            for s in sentences
+                        ]
+                        for task in self.tasks
+                        if task.type == CLASSIFICATION
+                    }
                 )
                 continue
 
@@ -313,7 +355,7 @@ class CnlpRestApp:
                 " ".join(s for j, s in enumerate(sentences) if j != i)
                 for i in range(len(sentences))
             ]
-            batch_texts = [text] + ablated
+            batch_texts = [text, *ablated]
 
             encoding = self.tokenizer(
                 batch_texts,
@@ -330,14 +372,25 @@ class CnlpRestApp:
 
             task_results: dict[str, list[dict]] = {}
             for task_ind, task in enumerate(self.tasks):
-                probs = torch.softmax(output.logits[task_ind], dim=-1)
-                pred_class = probs[0].argmax().item()
-                baseline_prob = probs[0, pred_class].item()
+                if task.type != CLASSIFICATION:
+                    self.logger.warning(
+                        f"Skipping sentence attributions for task {task.name}, since it is not a classification task."
+                    )
+                    continue
+
+                # probs[0] = full text, probs[1..N] = each sentence ablated
+                probs = torch.softmax(
+                    output.logits[task_ind], dim=-1
+                )  # (batch, num_labels)
+                baseline = probs[0]  # (num_labels,)
 
                 task_results[task.name] = [
                     {
                         "sentence": sent,
-                        "score": round(baseline_prob - probs[i + 1, pred_class].item(), 4),
+                        "scores": {
+                            label: round((baseline[c] - probs[i + 1, c]).item(), 4)
+                            for c, label in enumerate(task.labels)
+                        },
                     }
                     for i, sent in enumerate(sentences)
                 ]
@@ -366,7 +419,9 @@ class CnlpRestApp:
             hier_data_config = None
 
         text_list = input_doc.to_text_list()
-        dataset = self.create_prediction_dataset(text_list, max_seq_length, hier_data_config)
+        dataset = self.create_prediction_dataset(
+            text_list, max_seq_length, hier_data_config
+        )
         predictions = self.predict(dataset, max_seq_length)
         results = self.format_predictions(predictions)
 
@@ -387,7 +442,13 @@ class CnlpRestApp:
         return results
 
     def router(self, prefix: str = ""):
+        _visualizer_html = files("cnlpt.rest").joinpath("visualizer.html").read_text()
+
+        async def visualizer():
+            return HTMLResponse(_visualizer_html)
+
         router = APIRouter(prefix=prefix)
+        router.add_api_route("/", visualizer, methods=["GET"], include_in_schema=False)
         router.add_api_route("/process", self.process, methods=["POST"])
         return router
 

--- a/src/cnlpt/rest/visualizer.html
+++ b/src/cnlpt/rest/visualizer.html
@@ -1,0 +1,374 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>cnlp-transformers</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: #f8f9fa;
+      color: #212529;
+      padding: 2rem;
+    }
+    .container { max-width: 860px; margin: 0 auto; }
+    h1 { font-size: 1.4rem; margin-bottom: 1.5rem; color: #343a40; font-weight: 600; }
+
+    .card {
+      background: white;
+      border: 1px solid #dee2e6;
+      border-radius: 8px;
+      padding: 1.5rem;
+      margin-bottom: 1.25rem;
+    }
+
+    textarea {
+      width: 100%;
+      height: 100px;
+      border: 1px solid #ced4da;
+      border-radius: 4px;
+      padding: 0.5rem 0.75rem;
+      font-size: 0.95rem;
+      font-family: inherit;
+      resize: vertical;
+      line-height: 1.5;
+    }
+    textarea:focus { outline: none; border-color: #86b7fe; box-shadow: 0 0 0 3px rgba(13,110,253,.15); }
+
+    .options {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 0.75rem 1.25rem;
+      margin-top: 1rem;
+    }
+    .opt label { display: block; font-size: 0.8rem; color: #6c757d; margin-bottom: 0.25rem; }
+    .opt input[type=number] {
+      width: 100%;
+      border: 1px solid #ced4da;
+      border-radius: 4px;
+      padding: 0.3rem 0.5rem;
+      font-size: 0.9rem;
+    }
+
+    .checkboxes { display: flex; flex-direction: column; gap: 0.4rem; margin-top: 1rem; }
+    .checkboxes label { display: flex; align-items: center; gap: 0.5rem; font-size: 0.9rem; cursor: pointer; }
+
+    button#submit {
+      margin-top: 1rem;
+      background: #0d6efd;
+      color: white;
+      border: none;
+      padding: 0.45rem 1.25rem;
+      border-radius: 4px;
+      font-size: 0.9rem;
+      cursor: pointer;
+      font-weight: 500;
+    }
+    button#submit:hover { background: #0b5ed7; }
+    button#submit:disabled { background: #adb5bd; cursor: not-allowed; }
+
+    .task-name {
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.07em;
+      color: #6c757d;
+      font-weight: 600;
+      margin-bottom: 0.6rem;
+    }
+
+    .prediction { font-size: 1.1rem; margin-bottom: 0.6rem; }
+    .prediction strong { color: #0d6efd; }
+
+    .probs { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-bottom: 1rem; }
+    .prob { background: #f1f3f5; border-radius: 4px; padding: 0.2rem 0.5rem; font-size: 0.8rem; }
+    .prob.top { background: #dbe4ff; color: #364fc7; }
+
+    .attr-header {
+      display: flex; align-items: center; gap: 0.75rem;
+      font-size: 0.85rem; margin-bottom: 0.5rem;
+    }
+    .attr-header label { color: #495057; }
+    .attr-header select {
+      border: 1px solid #ced4da;
+      border-radius: 4px;
+      padding: 0.2rem 0.4rem;
+      font-size: 0.85rem;
+      background: white;
+    }
+
+    .legend {
+      display: flex; gap: 1rem; align-items: center;
+      font-size: 0.78rem; color: #6c757d; margin-bottom: 0.6rem;
+    }
+    .legend-swatch { width: 14px; height: 14px; border-radius: 2px; display: inline-block; vertical-align: middle; margin-right: 3px; }
+
+    .tokens { line-height: 2.4; font-size: 0.95rem; }
+    .tok {
+      display: inline;
+      border-radius: 3px;
+      padding: 0.12em 0;
+      position: relative;
+      cursor: default;
+    }
+    .tok:hover .tooltip { display: block; }
+    .tooltip {
+      display: none;
+      position: absolute;
+      bottom: calc(100% + 4px);
+      left: 50%;
+      transform: translateX(-50%);
+      background: #212529;
+      color: white;
+      font-size: 0.72rem;
+      padding: 0.3rem 0.5rem;
+      border-radius: 4px;
+      white-space: nowrap;
+      z-index: 100;
+      pointer-events: none;
+      font-family: 'Courier New', monospace;
+    }
+
+    .sent-attrs { margin-top: 1rem; }
+    .sent-label { font-size: 0.8rem; color: #6c757d; margin-bottom: 0.4rem; }
+    .sent-row { display: flex; gap: 0.6rem; font-size: 0.88rem; margin-bottom: 0.2rem; align-items: baseline; }
+    .sent-score { font-family: monospace; min-width: 7ch; }
+    .pos { color: #2f9e44; }
+    .neg { color: #e03131; }
+
+    .status { color: #6c757d; font-size: 0.9rem; }
+    .error { color: #e03131; font-size: 0.9rem; }
+
+    ul.results-list { font-size: 0.9rem; padding-left: 1.25rem; }
+    ul.results-list li { margin-bottom: 0.2rem; }
+    .empty { color: #6c757d; font-size: 0.9rem; }
+  </style>
+</head>
+<body>
+<div class="container">
+  <h1>cnlp-transformers</h1>
+
+  <div class="card">
+    <textarea id="text" placeholder="Enter text to analyze…"></textarea>
+
+    <div class="options">
+      <div class="opt">
+        <label>Max sequence length</label>
+        <input type="number" id="max_seq_length" value="128" min="1" max="4096">
+      </div>
+      <div class="opt">
+        <label>Chunk length</label>
+        <input type="number" id="chunk_len" placeholder="(none)">
+      </div>
+      <div class="opt">
+        <label>Num chunks</label>
+        <input type="number" id="num_chunks" placeholder="(none)">
+      </div>
+    </div>
+
+    <div class="checkboxes">
+      <label><input type="checkbox" id="prepend_empty_chunk"> Prepend empty chunk</label>
+      <label><input type="checkbox" id="return_attributions"> Return token attributions</label>
+      <label><input type="checkbox" id="return_sentence_attributions"> Return sentence attributions</label>
+    </div>
+
+    <button id="submit">Analyze</button>
+  </div>
+
+  <div id="results"></div>
+</div>
+
+<script>
+document.getElementById('submit').addEventListener('click', async () => {
+  const textEl = document.getElementById('text');
+  const text = textEl.value.trim();
+  if (!text) { textEl.focus(); return; }
+
+  const params = new URLSearchParams({
+    max_seq_length: document.getElementById('max_seq_length').value,
+    return_attributions: document.getElementById('return_attributions').checked,
+    return_sentence_attributions: document.getElementById('return_sentence_attributions').checked,
+    prepend_empty_chunk: document.getElementById('prepend_empty_chunk').checked,
+  });
+  const chunkLen = document.getElementById('chunk_len').value;
+  const numChunks = document.getElementById('num_chunks').value;
+  if (chunkLen) params.set('chunk_len', chunkLen);
+  if (numChunks) params.set('num_chunks', numChunks);
+
+  const btn = document.getElementById('submit');
+  btn.disabled = true;
+  const resultsEl = document.getElementById('results');
+  resultsEl.innerHTML = '<p class="status">Analyzing\u2026</p>';
+
+  try {
+    const res = await fetch('./process?' + params, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+    });
+    if (!res.ok) {
+      resultsEl.innerHTML = `<p class="error">Error ${res.status}: ${await res.text()}</p>`;
+      return;
+    }
+    renderResults(await res.json(), text, resultsEl);
+  } catch (e) {
+    resultsEl.innerHTML = `<p class="error">${e.message}</p>`;
+  } finally {
+    btn.disabled = false;
+  }
+});
+
+function renderResults(data, inputText, container) {
+  container.innerHTML = '';
+  for (const doc of data) {
+    for (const [taskName, task] of Object.entries(doc)) {
+      if (taskName === 'text') continue;
+      const card = el('div', { className: 'card' });
+      card.append(el('div', { className: 'task-name', textContent: taskName }));
+      if ('prediction' in task)   renderClassification(card, task, inputText);
+      else if ('spans' in task)   renderList(card, task.spans, 'spans', s => `${s.text} (${s.tag})`);
+      else if ('relations' in task) renderList(card, task.relations, 'relations', r => `${r.arg1_text} \u2192 ${r.arg2_text}: ${r.label}`);
+      container.appendChild(card);
+    }
+  }
+}
+
+function renderClassification(card, task, inputText) {
+  const probPct = task.probs ? (task.probs[task.prediction] * 100).toFixed(1) : null;
+  card.append(el('div', {
+    className: 'prediction',
+    innerHTML: `Prediction: <strong>${task.prediction}</strong>${probPct
+      ? ` <span style="color:#6c757d;font-size:.9em">(${probPct}%)</span>` : ''}`,
+  }));
+
+  if (task.probs) {
+    const probsEl = el('div', { className: 'probs' });
+    Object.entries(task.probs)
+      .sort(([, a], [, b]) => b - a)
+      .forEach(([label, p]) => probsEl.append(el('span', {
+        className: 'prob' + (label === task.prediction ? ' top' : ''),
+        textContent: `${label}: ${(p * 100).toFixed(1)}%`,
+      })));
+    card.append(probsEl);
+  }
+
+  if (task.attributions?.length) {
+    const labels = Object.keys(task.attributions[0].scores);
+
+    const header = el('div', { className: 'attr-header' });
+    header.append(el('label', { textContent: 'Scores for class:' }));
+    const select = el('select');
+    labels.forEach(lbl => {
+      const opt = el('option', { value: lbl, textContent: lbl });
+      if (lbl === task.prediction) opt.selected = true;
+      select.append(opt);
+    });
+    header.append(select);
+
+    const legend = el('div', { className: 'legend' });
+    legend.innerHTML =
+      `<span class="legend-swatch" style="background:rgba(47,158,68,.65)"></span>supports class` +
+      `&ensp;<span class="legend-swatch" style="background:rgba(224,49,49,.65)"></span>suppresses class`;
+
+    const tokensEl = el('div', { className: 'tokens' });
+
+    const draw = label => {
+      tokensEl.innerHTML = '';
+      const real = task.attributions
+        .filter(t => !(t.start === 0 && t.end === 0))
+        .sort((a, b) => a.start - b.start);
+
+      let cursor = 0;
+      for (const tok of real) {
+        // Fill any gap between tokens (spaces, punctuation) with plain text.
+        if (tok.start > cursor) {
+          tokensEl.append(document.createTextNode(inputText.slice(cursor, tok.start)));
+        }
+
+        const score = tok.scores[label] ?? 0;
+        const [r, g, b] = score >= 0 ? [47, 158, 68] : [224, 49, 49];
+        const alpha = Math.min(Math.abs(score), 1) * 0.65;
+
+        const span = el('span', {
+          className: 'tok',
+          textContent: inputText.slice(tok.start, tok.end),
+        });
+        span.style.backgroundColor = `rgba(${r},${g},${b},${alpha})`;
+
+        const tip = el('div', {
+          className: 'tooltip',
+          textContent: Object.entries(tok.scores)
+            .map(([l, s]) => `${l}: ${s >= 0 ? '+' : ''}${s.toFixed(4)}`).join('  \u00b7  '),
+        });
+        span.append(tip);
+        tokensEl.append(span);
+        cursor = tok.end;
+      }
+      // Any trailing text after the last token.
+      if (cursor < inputText.length) {
+        tokensEl.append(document.createTextNode(inputText.slice(cursor)));
+      }
+    };
+
+    draw(task.prediction);
+    select.addEventListener('change', () => draw(select.value));
+    card.append(header, legend, tokensEl);
+  }
+
+  if (task.sentence_attributions?.length) {
+    const labels = Object.keys(task.sentence_attributions[0].scores);
+
+    const wrap = el('div', { className: 'sent-attrs' });
+
+    const header = el('div', { className: 'attr-header' });
+    header.append(el('label', { textContent: 'Sentence scores for class:' }));
+    const select = el('select');
+    labels.forEach(lbl => {
+      const opt = el('option', { value: lbl, textContent: lbl });
+      if (lbl === task.prediction) opt.selected = true;
+      select.append(opt);
+    });
+    header.append(select);
+    wrap.append(header);
+
+    const listEl = el('div');
+    const draw = label => {
+      listEl.innerHTML = '';
+      for (const s of task.sentence_attributions) {
+        const score = s.scores[label] ?? 0;
+        const row = el('div', { className: 'sent-row' });
+        const positive = score >= 0;
+        row.append(
+          el('span', {
+            className: 'sent-score ' + (positive ? 'pos' : 'neg'),
+            textContent: `${positive ? '+' : ''}${score.toFixed(4)}`,
+          }),
+          el('span', { textContent: s.sentence }),
+        );
+        listEl.append(row);
+      }
+    };
+
+    draw(task.prediction);
+    select.addEventListener('change', () => draw(select.value));
+    wrap.append(listEl);
+    card.append(wrap);
+  }
+}
+
+function renderList(card, items, kind, fmt) {
+  if (!items?.length) {
+    card.append(el('p', { className: 'empty', textContent: `No ${kind} found.` }));
+    return;
+  }
+  const list = el('ul', { className: 'results-list' });
+  items.forEach(item => list.append(el('li', { textContent: fmt(item) })));
+  card.append(list);
+}
+
+function el(tag, props = {}) {
+  return Object.assign(document.createElement(tag), props);
+}
+</script>
+</body>
+</html>

--- a/test/api/test_attributions.py
+++ b/test/api/test_attributions.py
@@ -1,0 +1,167 @@
+"""
+Tests for per-class token and sentence attribution methods on the REST API.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cnlpt.rest.cnlp_rest import CnlpRestApp, InputDocument
+
+NEGATION_MODEL = "mlml-chip/negation_pubmedbert_sharpseed"
+
+# Single sentence — used for token attribution tests and the single-sentence
+# edge case in sentence attribution tests.
+SINGLE_SENTENCE = "The patient denied any chest pain."
+
+# Three sentences — used to verify sentence attribution returns one entry per
+# sentence and that multi-sentence scores are non-trivially computed.
+MULTI_SENTENCE = (
+    "The patient denied any chest pain. "
+    "She reported no shortness of breath. "
+    "There were no signs of infection."
+)
+
+
+@pytest.fixture(scope="module")
+def negation_client():
+    with TestClient(CnlpRestApp(NEGATION_MODEL).fastapi()) as client:
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Token attributions
+# ---------------------------------------------------------------------------
+
+
+class TestTokenAttributions:
+    @pytest.fixture(scope="class")
+    def response(self, negation_client):
+        doc = InputDocument(text=SINGLE_SENTENCE)
+        r = negation_client.post(
+            "/process?return_attributions=true",
+            content=doc.json(),
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def test_attributions_present(self, response):
+        assert "attributions" in _task(response)
+
+    def test_attributions_absent_by_default(self, negation_client):
+        doc = InputDocument(text=SINGLE_SENTENCE)
+        r = negation_client.post("/process", content=doc.json())
+        r.raise_for_status()
+        assert "attributions" not in _task(r.json())
+
+    def test_token_dict_keys(self, response):
+        for tok in _task(response)["attributions"]:
+            assert set(tok.keys()) == {"token_id", "start", "end", "scores"}
+
+    def test_token_id_is_int(self, response):
+        for tok in _task(response)["attributions"]:
+            assert isinstance(tok["token_id"], int)
+
+    def test_offsets_are_non_negative_and_ordered(self, response):
+        for tok in _task(response)["attributions"]:
+            assert tok["start"] >= 0
+            assert tok["end"] >= tok["start"]
+
+    def test_all_labels_have_a_score_per_token(self, response):
+        result = response[0]
+        task_name = _task_name(result)
+        expected_labels = set(result[task_name]["probs"].keys())
+        for tok in result[task_name]["attributions"]:
+            assert set(tok["scores"].keys()) == expected_labels
+
+    def test_scores_are_in_range(self, response):
+        for tok in _task(response)["attributions"]:
+            for score in tok["scores"].values():
+                assert -1.0 <= score <= 1.0
+
+    def test_special_tokens_have_zero_offsets(self, response):
+        # [CLS] and [SEP] are always present and should have start == end == 0.
+        special = [
+            t
+            for t in _task(response)["attributions"]
+            if t["start"] == 0 and t["end"] == 0
+        ]
+        assert len(special) >= 2
+
+    def test_non_special_token_offsets_are_within_input(self, response):
+        text = response[0]["text"]
+        real_tokens = [
+            t
+            for t in _task(response)["attributions"]
+            if not (t["start"] == 0 and t["end"] == 0)
+        ]
+        assert len(real_tokens) > 0
+        for tok in real_tokens:
+            assert 0 <= tok["start"] < tok["end"] <= len(text)
+
+
+# ---------------------------------------------------------------------------
+# Sentence attributions
+# ---------------------------------------------------------------------------
+
+
+class TestSentenceAttributions:
+    @pytest.fixture(scope="class")
+    def response(self, negation_client):
+        doc = InputDocument(text=MULTI_SENTENCE)
+        r = negation_client.post(
+            "/process?return_sentence_attributions=true",
+            content=doc.json(),
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def test_sentence_attributions_present(self, response):
+        assert "sentence_attributions" in _task(response)
+
+    def test_sentence_attributions_absent_by_default(self, negation_client):
+        doc = InputDocument(text=MULTI_SENTENCE)
+        r = negation_client.post("/process", content=doc.json())
+        r.raise_for_status()
+        assert "sentence_attributions" not in _task(r.json())
+
+    def test_sentence_dict_keys(self, response):
+        for sent in _task(response)["sentence_attributions"]:
+            assert set(sent.keys()) == {"sentence", "scores"}
+
+    def test_all_labels_have_a_score_per_sentence(self, response):
+        result = response[0]
+        task_name = _task_name(result)
+        expected_labels = set(result[task_name]["probs"].keys())
+        for sent in result[task_name]["sentence_attributions"]:
+            assert set(sent["scores"].keys()) == expected_labels
+
+    def test_sentence_count_matches_input(self, response):
+        assert len(_task(response)["sentence_attributions"]) == 3
+
+    def test_single_sentence_scores_are_zero(self, negation_client):
+        # With only one sentence, ablation has nothing to remove — all scores
+        # should be 0.0.
+        doc = InputDocument(text=SINGLE_SENTENCE)
+        r = negation_client.post(
+            "/process?return_sentence_attributions=true",
+            content=doc.json(),
+        )
+        r.raise_for_status()
+        sents = _task(r.json())["sentence_attributions"]
+        assert len(sents) == 1
+        for score in sents[0]["scores"].values():
+            assert score == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _task_name(result: dict) -> str:
+    return next(k for k in result if k != "text")
+
+
+def _task(data: list) -> dict:
+    result = data[0]
+    return result[_task_name(result)]

--- a/test/common/fixtures.py
+++ b/test/common/fixtures.py
@@ -19,11 +19,16 @@ from cnlpt.modeling import (
 from cnlpt.train_system import CnlpTrainingArguments, CnlpTrainSystem
 
 
-@pytest.fixture(autouse=True)
-def disable_mps_for_ci(monkeypatch):
+@pytest.fixture(scope="session", autouse=True)
+def disable_mps_for_ci():
     """Disable MPS for CI"""
-    if os.getenv("CI", False):
-        monkeypatch.setattr("torch._C._mps_is_available", lambda: False)
+    if os.getenv("CI"):
+        mp = pytest.MonkeyPatch()
+        mp.setattr("torch._C._mps_is_available", lambda: False)
+        yield
+        mp.undo()
+    else:
+        yield
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
### Summary

Lots of help from Claude on this one, but carefully steered and scrutinized by me.

- Adds two new interpretation methods to the REST API: gradient-based token attributions and leave-one-out sentence attributions. This is adapted from @tmills `rest_interp` branch, slightly modified to return signed per-class scores rather than a single unsigned saliency score
- Adds a `GET /` endpoint that serves an interactive HTML visualizer for exploring model predictions and attributions
- Adds tests for both attribution methods against the existing negation model

### Token attributions (`return_attributions=true`)

Uses the **input × gradient** method: one forward pass through the encoder, then one backward pass per class label (reusing the computation graph via `retain_graph=True`). The signed dot product of gradient and embedding over the hidden dimension gives a per-token, per-class score in `[-1, 1]`:
- **Positive**: token pushes the model toward that class
- **Negative**: token pushes the model away from that class

Each token in the response includes `token_id`, character-level `start`/`end` offsets into the original input string, and a `scores` dict keyed by label. Special tokens (`[CLS]`, `[SEP]`) are included with `start == end == 0`. Only classification tasks are supported; tagging and relations tasks log a warning and are skipped.

### Sentence attributions (`return_sentence_attributions=true`)

Uses **leave-one-out ablation**: runs one batched forward pass over the full text and each ablated variant (one sentence removed), then for each class computes `p(class | full) − p(class | ablated)`. Scores are per-class and signed with the same polarity convention. Single-sentence inputs return a score of `0.0` for all classes.

### Visualizer (`GET /`)

A self-contained HTML page (no external dependencies) served at the root of each model's route prefix. Features:
- Form controls for all `/process` query parameters
- Classification results with prediction, per-class probability badges
- Token attribution display: original text rendered with colored highlights (green/red by class score intensity), class selector dropdown, hover tooltips showing all class scores
- Sentence attribution display with signed scores and class selector
- Basic span/relation lists for tagging and relation tasks

The HTML file is bundled as package data via `importlib.resources` and declared in `pyproject.toml` so it is included correctly in installed wheels.

<img width="744" height="756" alt="image" src="https://github.com/user-attachments/assets/a418caa0-855e-4cbb-80d7-0577a3f0d12a" />
